### PR TITLE
Add WatchPath struct

### DIFF
--- a/src/Event.zig
+++ b/src/Event.zig
@@ -1,6 +1,12 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 const WatchHandle = @import("Watcher.zig").WatchHandle;
+
+pub const mapPlatform = switch (builtin.os.tag) {
+    .linux => @import("backends/linux.zig").mapInotify,
+    else => @compileError("Unsupported OS"),
+};
 
 pub const EventType = enum {
     Create,
@@ -8,38 +14,28 @@ pub const EventType = enum {
     Delete,
 };
 
-pub const EventMask = u32;
-
-pub const EventMaskCreate = 1 << 0;
-pub const EventMaskModify = 1 << 1;
-pub const EventMaskDelete = 1 << 2;
-pub const EventMaskAll = 0xFFFFFFFF;
-
 pub const EventFilter = struct {
     create: bool = true,
     modify: bool = true,
     delete: bool = true,
 
-    pub fn fromBits(bits: EventMask) EventFilter {
-        return EventFilter{
-            .create = (bits & EventMaskCreate) != 0,
-            .modify = (bits & EventMaskModify) != 0,
-            .delete = (bits & EventMaskDelete) != 0,
-        };
-    }
-
     pub fn toBits(self: EventFilter) u32 {
-        var result: u32 = 0;
-        if (self.create) result |= EventMaskCreate;
-        if (self.modify) result |= EventMaskModify;
-        if (self.delete) result |= EventMaskDelete;
-        return result;
+        var mask: u32 = 0;
+        inline for (mapPlatform) |map| {
+            const include = switch (map.event) {
+                .Create => self.create,
+                .Modify => self.modify,
+                .Delete => self.delete,
+            };
+            if (include) mask |= map.mask;
+        }
+        return mask;
     }
 };
 
 pub const Event = struct {
     handle: WatchHandle,
-    type: EventMask,
+    type: EventType,
     path: []const u8,
     timestamp: i64,
     extra: ?EventExtra,

--- a/src/Watcher.zig
+++ b/src/Watcher.zig
@@ -1,9 +1,41 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+pub const WatchPath = struct {
+    const Self = @This();
+    buffer: std.BoundedArray(u8, 256),
+    fallback: ?[]const u8 = null,
+
+    pub fn init(target: []const u8, allocator: std.mem.Allocator) !Self {
+        var result = Self{ .buffer = .{} };
+
+        if (target.len < result.buffer.capacity()) {
+            try result.buffer.appendSlice(target);
+        } else {
+            result.fallback = try allocator.dupe(u8, target);
+        }
+
+        return result;
+    }
+
+    pub fn path(self: *const Self) []const u8 {
+        return self.fallback orelse self.buffer.slice();
+    }
+
+    pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
+        if (self.fallback) |fb| allocator.free(fb);
+    }
+};
+
+pub const WatchConfig = struct {
+    path: WatchPath,
+    timeout: u32,
+    debounce: u3,
+};
+
 pub const Watcher = switch (builtin.os.tag) {
     .linux => @import("backends/linux.zig").LinuxWatcher,
     else => @compileError("Unsupported OS"),
 };
 
-pub const WatchHandle = usize;
+pub const WatchHandle = isize;

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 pub const Watcher = @import("Watcher.zig").Watcher;
+pub const WatchPath = @import("Watcher.zig").WatchPath;
 pub const Event = @import("Event.zig").Event;
 pub const EventFilter = @import("Event.zig").EventFilter;
 


### PR DESCRIPTION
avoids allocation on short path names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added WatchPath for safer, flexible path watching.
  - Introduced configurable watch options (timeout, debounce).
  - Switched to clear event types (Create, Modify, Delete).
  - Improved runtime logging and error handling in the example.

- Refactor
  - Updated APIs to accept WatchPath instead of raw paths.
  - Streamlined event filtering via platform mappings.
  - Adjusted watch handle type for consistency.

- Chores
  - Re-exported WatchPath for easier access.
  - Platform support clarified; non-Linux targets will fail at compile time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->