### PR TITLE
Update for Zig 0.15.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -10,7 +10,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "zigwatch",
         .root_module = zigwatchMod,
     });
@@ -18,12 +18,11 @@ pub fn build(b: *std.Build) void {
     lib.linkLibC();
     b.installArtifact(lib);
 
-    const example = b.addExecutable(.{
-        .name = "simple_example",
+    const example = b.addExecutable(.{ .name = "simple_example", .root_module = b.createModule(.{
         .root_source_file = .{ .cwd_relative = "examples/simple.zig" },
         .target = target,
         .optimize = optimize,
-    });
+    }) });
 
     example.linkLibrary(lib);
     example.root_module.addImport("zigwatch", zigwatchMod);

--- a/examples/simple.zig
+++ b/examples/simple.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const zw = @import("zigwatch");
 
 pub fn main() !void {
-    const fd = zw.Watcher.init();
+    const fd = try zw.Watcher.init();
     // TODO: Add error handling
     std.log.info("Watcher created: {}", .{fd});
     defer _ = std.posix.close(@intCast(fd));
@@ -10,9 +10,9 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var target = try zw.WatchPath.init("/home/", allocator);
+    var target = try zw.WatchPath.init(".", allocator);
     defer _ = target.deinit(allocator);
-    const wd = zw.Watcher.add_watch(fd, target, .{ .modify = true });
+    const wd = try zw.Watcher.add_watch(fd, target, .{ .modify = true });
     std.log.info("Watch added: {}", .{wd});
     // TODO: Expand example as API matures
 }

--- a/examples/simple.zig
+++ b/examples/simple.zig
@@ -10,7 +10,7 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var target = try zw.WatchPath.init(".", allocator);
+    var target = try zw.WatchPath.init("/home/", allocator);
     defer _ = target.deinit(allocator);
     const wd = zw.Watcher.add_watch(fd, target, .{ .modify = true });
     std.log.info("Watch added: {}", .{wd});

--- a/scripts/dev-session.sh
+++ b/scripts/dev-session.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 tmux new-session -d -s dev -n edit 'hx .'
 tmux split-window -h -t dev:0 'just watch'
-tmux split-window -v -t dev:0.1 'bash'
+tmux split-window -v -t dev:0.1
 tmux select-pane -t dev:0.0
 tmux resize-pane -t dev:0.1 -D 6
 tmux resize-pane -t dev:0.0 -R 12

--- a/src/Error.zig
+++ b/src/Error.zig
@@ -1,0 +1,9 @@
+pub const FsEventError = error{
+    FileNotFound,
+    PermissionDenied,
+    OutOfMemory,
+    InvalidArguments,
+    TooManyOpenFiles,
+    NameTooLong,
+    Unexpected,
+};

--- a/src/Watcher.zig
+++ b/src/Watcher.zig
@@ -3,14 +3,15 @@ const builtin = @import("builtin");
 
 pub const WatchPath = struct {
     const Self = @This();
-    buffer: std.BoundedArray(u8, 256),
+    buffer: [256]u8 = undefined,
     fallback: ?[]const u8 = null,
 
     pub fn init(target: []const u8, allocator: std.mem.Allocator) !Self {
-        var result = Self{ .buffer = .{} };
+        var result = Self{};
 
-        if (target.len < result.buffer.capacity()) {
-            try result.buffer.appendSlice(target);
+        if (target.len < result.buffer.len) {
+            @memcpy(result.buffer[0..target.len], target);
+            result.buffer[target.len] = 0;
         } else {
             result.fallback = try allocator.dupe(u8, target);
         }
@@ -19,7 +20,7 @@ pub const WatchPath = struct {
     }
 
     pub fn path(self: *const Self) []const u8 {
-        return self.fallback orelse self.buffer.slice();
+        return self.fallback orelse self.buffer[0..];
     }
 
     pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {

--- a/src/backends/linux.zig
+++ b/src/backends/linux.zig
@@ -8,6 +8,8 @@ const inotify = @cImport({
     @cInclude("sys/inotify.h");
 });
 
+const FsEventError = @import("../Error.zig").FsEventError;
+
 const IN_ACCESS = inotify.IN_ACCESS;
 const IN_ATTRIB = inotify.IN_ATTRIB;
 const IN_CLOSE_WRITE = inotify.IN_CLOSE_WRITE;
@@ -29,22 +31,36 @@ pub const mapInotify = [_]struct { mask: u32, event: EventType }{
     .{ .mask = IN_DELETE, .event = .Delete },
 };
 
+const mapFsEventError = [_]struct { posix: std.posix.E, err: FsEventError }{
+    .{ .posix = .NOENT, .err = FsEventError.FileNotFound },
+    .{ .posix = .PERM, .err = FsEventError.PermissionDenied },
+    .{ .posix = .NOMEM, .err = FsEventError.OutOfMemory },
+    .{ .posix = .INVAL, .err = FsEventError.InvalidArguments },
+    .{ .posix = .MFILE, .err = FsEventError.TooManyOpenFiles },
+    .{ .posix = .NFILE, .err = FsEventError.TooManyOpenFiles },
+    .{ .posix = .NAMETOOLONG, .err = FsEventError.NameTooLong },
+};
+
+fn errnoToFsEventError(err: std.posix.E) FsEventError {
+    inline for (mapFsEventError) |entry| {
+        if (err == entry.posix) return entry.err;
+    }
+    return FsEventError.Unexpected;
+}
+
 pub const LinuxWatcher = struct {
-    pub fn init() WatchHandle {
+    pub fn init() !WatchHandle {
         const fd = inotify.inotify_init();
         if (fd == -1) {
-            _ = std.posix.errno(fd);
-            // TODO: Return error on failure
+            return errnoToFsEventError(std.posix.errno(fd));
         }
         return @intCast(fd);
     }
 
-    pub fn add_watch(fd: WatchHandle, target: WatchPath, mask: EventFilter) WatchHandle {
-        const wd = inotify.inotify_add_watch(@intCast(fd), target.path().ptr, mask.toBits());
-        std.log.debug("{s}\n", .{target.path()});
+    pub fn add_watch(fd: WatchHandle, target: WatchPath, mask: EventFilter) !WatchHandle {
+        const wd = inotify.inotify_add_watch(@intCast(fd), target.cstr(), mask.toBits());
         if (wd == -1) {
-            _ = std.posix.errno(wd);
-            // TODO: Return error on failure
+            return errnoToFsEventError(std.posix.errno(wd));
         }
         return @intCast(wd);
     }

--- a/src/backends/linux.zig
+++ b/src/backends/linux.zig
@@ -32,13 +32,20 @@ pub const mapInotify = [_]struct { mask: u32, event: EventType }{
 pub const LinuxWatcher = struct {
     pub fn init() WatchHandle {
         const fd = inotify.inotify_init();
-        // TODO: Return error on failed init
+        if (fd == -1) {
+            _ = std.posix.errno(fd);
+            // TODO: Return error on failure
+        }
         return @intCast(fd);
     }
 
     pub fn add_watch(fd: WatchHandle, target: WatchPath, mask: EventFilter) WatchHandle {
         const wd = inotify.inotify_add_watch(@intCast(fd), target.path().ptr, mask.toBits());
-        // TODO: Return error on failure
+        std.log.debug("{s}\n", .{target.path()});
+        if (wd == -1) {
+            _ = std.posix.errno(wd);
+            // TODO: Return error on failure
+        }
         return @intCast(wd);
     }
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Introduced a standardized filesystem error type for clearer error reporting.
* Bug Fixes
  * Improved error propagation and handling on Linux watcher initialization and adding watches.
* Chores
  * Dev session updated to open the default shell in the secondary pane.
  * Example updated to propagate watcher errors to main.
* Refactor
  * Streamlined watcher path storage and access; build now uses a module-based executable setup and generic library target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->