### PR TITLE
Foundation for polling and events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .zig-cache/
 zig-out/
+.direnv/
 

--- a/build.zig
+++ b/build.zig
@@ -8,6 +8,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = .{ .cwd_relative = "src/root.zig" },
         .target = target,
         .optimize = optimize,
+        .link_libc = false,
     });
 
     const lib = b.addLibrary(.{
@@ -15,7 +16,6 @@ pub fn build(b: *std.Build) void {
         .root_module = zigwatchMod,
     });
 
-    lib.linkLibC();
     b.installArtifact(lib);
 
     const example = b.addExecutable(.{ .name = "simple_example", .root_module = b.createModule(.{

--- a/build.zig
+++ b/build.zig
@@ -22,6 +22,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = .{ .cwd_relative = "examples/simple.zig" },
         .target = target,
         .optimize = optimize,
+        .link_libc = false,
     }) });
 
     example.linkLibrary(lib);

--- a/examples/simple.zig
+++ b/examples/simple.zig
@@ -13,7 +13,6 @@ pub fn main() !void {
     var target = try zw.WatchPath.init(".", allocator);
     defer _ = target.deinit(allocator);
     const wd = try watcher.add_watch(target, .{ .create = true, .delete = true });
-    std.posix.close(@intCast(wd));
     std.log.info("Watch added: {}", .{wd});
     // TODO: Expand example as API matures
     var dir = try std.fs.Dir.openDir(std.fs.cwd(), target.path(), .{});

--- a/examples/simple.zig
+++ b/examples/simple.zig
@@ -15,10 +15,10 @@ pub fn main() !void {
     const wd = try watcher.add_watch(target, .{ .create = true, .delete = true });
     std.log.info("Watch added: {}", .{wd});
     // TODO: Expand example as API matures
-    var dir = try std.fs.Dir.openDir(std.fs.cwd(), target.path(), .{});
+    var dir = try std.fs.cwd().openDir(target.path(), .{});
     const fd = try dir.createFile("test.txt", .{});
     _ = try dir.deleteFile("test.txt");
-    defer _ = std.fs.File.close(fd);
+    defer fd.close();
     defer dir.close();
     _ = try watcher.poll();
 }

--- a/flake.lock
+++ b/flake.lock
@@ -236,11 +236,11 @@
         "zls": "zls"
       },
       "locked": {
-        "lastModified": 1756517097,
-        "narHash": "sha256-StZm4ge7LcV3Ww5sP3pPKXqoem79zKAEt2vdhBJOKeA=",
+        "lastModified": 1760076974,
+        "narHash": "sha256-8J3gf+cP5+dUxaRFfnCaWfBHBz988nYeftAwGsQ/exs=",
         "owner": "penuvil",
         "repo": "zig-common",
-        "rev": "21f291e12334f4dbd6cb933e476816e6e9fec927",
+        "rev": "339319a6e115be11c34ebbe4e72056c4f5717c6c",
         "type": "github"
       },
       "original": {

--- a/src/Event.zig
+++ b/src/Event.zig
@@ -3,11 +3,6 @@ const builtin = @import("builtin");
 
 const WatchHandle = @import("Watcher.zig").WatchHandle;
 
-pub const mapPlatform = switch (builtin.os.tag) {
-    .linux => @import("backends/linux.zig").mapInotifyEvent,
-    else => @compileError("Unsupported OS"),
-};
-
 pub const EventType = enum {
     Create,
     Modify,
@@ -18,20 +13,6 @@ pub const EventFilter = struct {
     create: bool = false,
     modify: bool = false,
     delete: bool = false,
-
-    pub fn toBits(self: EventFilter) u32 {
-        var mask: u32 = 0;
-        inline for (mapPlatform) |map| {
-            const include = switch (map.event) {
-                .Create => self.create,
-                .Modify => self.modify,
-                .Delete => self.delete,
-            };
-            if (include) mask |= map.mask;
-        }
-        std.log.debug("{}", .{mask});
-        return mask;
-    }
 };
 
 pub const Event = struct {

--- a/src/Event.zig
+++ b/src/Event.zig
@@ -4,7 +4,7 @@ const builtin = @import("builtin");
 const WatchHandle = @import("Watcher.zig").WatchHandle;
 
 pub const mapPlatform = switch (builtin.os.tag) {
-    .linux => @import("backends/linux.zig").mapInotify,
+    .linux => @import("backends/linux.zig").mapInotifyEvent,
     else => @compileError("Unsupported OS"),
 };
 
@@ -15,9 +15,9 @@ pub const EventType = enum {
 };
 
 pub const EventFilter = struct {
-    create: bool = true,
-    modify: bool = true,
-    delete: bool = true,
+    create: bool = false,
+    modify: bool = false,
+    delete: bool = false,
 
     pub fn toBits(self: EventFilter) u32 {
         var mask: u32 = 0;
@@ -29,6 +29,7 @@ pub const EventFilter = struct {
             };
             if (include) mask |= map.mask;
         }
+        std.log.debug("{}", .{mask});
         return mask;
     }
 };

--- a/src/backends/linux.zig
+++ b/src/backends/linux.zig
@@ -73,7 +73,9 @@ pub const LinuxWatcher = struct {
     }
 
     pub fn add_watch(self: *const Self, target: WatchPath, filter: EventFilter) !WatchHandle {
-        const wd = linux.inotify_add_watch(@intCast(self.wfd), target.cstr(), eventFilterToBits(filter));
+        const mask = eventFilterToBits(filter);
+        if (mask == 0) return FsEventError.InvalidArguments;
+        const wd = linux.inotify_add_watch(@intCast(self.wfd), target.cstr(), mask);
         if (wd < 0) {
             return errnoToFsEventError(std.posix.errno(wd));
         }


### PR DESCRIPTION
This commit contains the following changes:
    M .gitignore
    M build.zig
    M examples/simple.zig
    M flake.lock
    M src/Event.zig
    M src/backends/linux.zig

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Watcher API moved to an instance-based model with lifecycle methods; watch addition and polling are instance-driven.
  * Default event filters for create/modify/delete are now disabled by default.
  * Public API surface adjusted (updated types/signatures) and Linux backend rewritten for more reliable event delivery.

* **Examples**
  * Sample flow expanded to demonstrate opening directories, creating/deleting files, and using the watcher poll lifecycle.

* **Chores**
  * Development ignore list expanded to include local environment cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->