### PR TITLE
added watch map and improved event processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .zig-cache/
 zig-out/
 .direnv/
+session-*
 

--- a/examples/simple.zig
+++ b/examples/simple.zig
@@ -2,23 +2,24 @@ const std = @import("std");
 const zw = @import("zigwatch");
 
 pub fn main() !void {
-    var watcher = try zw.Watcher.init();
-    // TODO: Add error handling
-    std.log.info("Watcher created: {}", .{watcher.wfd});
-    defer watcher.deinit();
     var gpa: std.heap.GeneralPurposeAllocator(.{}) = .init;
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var target = try zw.WatchPath.init(".", allocator);
-    defer _ = target.deinit(allocator);
-    const wd = try watcher.add_watch(target, .{ .create = true, .delete = true });
-    std.log.info("Watch added: {}", .{wd});
-    // TODO: Expand example as API matures
-    var dir = try std.fs.cwd().openDir(target.path(), .{});
+    var watcher = try zw.Watcher.init(allocator);
+    defer watcher.deinit();
+
+    const wd = try watcher.add_watch(".", .{ .create = true, .delete = true });
+    defer watcher.rm_watch(wd) catch {};
+    var dir = try std.fs.cwd().openDir(".", .{});
     const fd = try dir.createFile("test.txt", .{});
     _ = try dir.deleteFile("test.txt");
-    defer fd.close();
-    defer dir.close();
-    _ = try watcher.poll();
+    fd.close();
+    dir.close();
+    if (try watcher.poll(0)) |it| {
+        var it_mut = it;
+        while (try it_mut.next()) |event| {
+            std.log.info("Got event: {} for handle: {} and path: {s}", .{ event.type, event.handle, event.path });
+        }
+    }
 }

--- a/scripts/dev-session.sh
+++ b/scripts/dev-session.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-tmux new-session -d -s dev -n edit 'hx .'
+tmux new-session -d -s dev -n edit 'nvim .'
 tmux split-window -h -t dev:0 'just watch'
 tmux split-window -v -t dev:0.1
 tmux select-pane -t dev:0.0

--- a/src/Event.zig
+++ b/src/Event.zig
@@ -1,6 +1,3 @@
-const std = @import("std");
-const builtin = @import("builtin");
-
 const WatchHandle = @import("Watcher.zig").WatchHandle;
 
 pub const EventType = enum {

--- a/src/Watcher.zig
+++ b/src/Watcher.zig
@@ -1,50 +1,56 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const Event = @import("Event.zig").Event;
+const EventFilter = @import("Event.zig").EventFilter;
 
-pub const WatchPath = struct {
-    const Self = @This();
-    buffer: [256]u8 = undefined,
-    len: usize = 0,
-    fallback: ?[]const u8 = null,
-
-    pub fn init(target: []const u8, allocator: std.mem.Allocator) !Self {
-        var result = Self{};
-
-        if (target.len < result.buffer.len) {
-            @memcpy(result.buffer[0..target.len], target);
-            result.buffer[target.len] = 0;
-            result.len = target.len;
-        } else {
-            result.fallback = try allocator.dupeZ(u8, target);
-        }
-
-        return result;
-    }
-
-    pub fn path(self: *const Self) []const u8 {
-        if (self.fallback) |fb| return std.mem.sliceTo(fb, 0);
-        return self.buffer[0..self.len];
-    }
-
-    pub fn cstr(self: *const Self) [*:0]const u8 {
-        if (self.fallback) |fb| return fb[0..fb.len :0].ptr;
-        return self.buffer[0..self.len :0].ptr;
-    }
-
-    pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
-        if (self.fallback) |fb| allocator.free(fb);
-    }
-};
-
-pub const WatchConfig = struct {
-    path: WatchPath,
-    timeout: u32,
-    debounce: u3,
-};
-
-pub const Watcher = switch (builtin.os.tag) {
+pub const Backend = switch (builtin.os.tag) {
     .linux => @import("backends/linux.zig").LinuxWatcher,
     else => @compileError("Unsupported OS"),
+};
+
+pub const Watcher = union(enum) {
+    backend: Backend,
+
+    pub fn init(allocator: std.mem.Allocator) !Watcher {
+        const backend = try Backend.init(allocator);
+        return .{
+            .backend = backend,
+        };
+    }
+
+    pub fn add_watch(self: *Watcher, path: []const u8, mask: EventFilter) !WatchHandle {
+        return self.backend.add_watch(path, mask);
+    }
+
+    pub fn rm_watch(self: *Watcher, handle: WatchHandle) !void {
+        return self.backend.rm_watch(handle);
+    }
+
+    pub fn poll(self: *Watcher, timeout_ms: ?i32) !?EventIterator {
+        if (try self.backend.poll(timeout_ms)) {
+            return EventIterator{ .watcher = self };
+        } else {
+            return null;
+        }
+    }
+
+    fn nextEvent(self: *Watcher, it: *EventIterator) !?Event {
+        return self.backend.nextEvent(it);
+    }
+
+    pub fn deinit(self: *Watcher) void {
+        self.backend.deinit();
+    }
+};
+
+pub const EventIterator = struct {
+    const Self = @This();
+    watcher: *Watcher,
+    offset: usize = 0,
+
+    pub fn next(self: *Self) !?Event {
+        return self.watcher.nextEvent(self);
+    }
 };
 
 pub const WatchHandle = isize;

--- a/src/backends/linux.zig
+++ b/src/backends/linux.zig
@@ -5,8 +5,8 @@ const IN = linux.IN;
 const EventFilter = @import("../Event.zig").EventFilter;
 const EventType = @import("../Event.zig").EventType;
 const Event = @import("../Event.zig").Event;
+const EventIterator = @import("../Watcher.zig").EventIterator;
 const WatchHandle = @import("../Watcher.zig").WatchHandle;
-const WatchPath = @import("../Watcher.zig").WatchPath;
 
 const FsEventError = @import("../Error.zig").FsEventError;
 
@@ -26,13 +26,13 @@ fn eventFilterToBits(filter: EventFilter) u32 {
         };
         if (include) mask |= map.mask;
     }
-    std.log.debug("{}", .{mask});
     return mask;
 }
 
 fn inotifyEventToEvent(mask: u32) !EventType {
+    const event_mask = mask & (IN.CREATE | IN.MODIFY | IN.DELETE);
     inline for (mapInotifyEvent) |entry| {
-        if ((mask & entry.mask) != 0) return entry.event;
+        if (event_mask == entry.mask) return entry.event;
     }
     return FsEventError.Unexpected;
 }
@@ -56,63 +56,137 @@ fn errnoToFsEventError(err: std.posix.E) FsEventError {
 
 pub const LinuxWatcher = struct {
     const Self = @This();
-    wfd: WatchHandle,
-    poller: LinuxPoller,
+    const Handle = WatchHandle;
 
-    pub fn init() !Self {
+    wfd: Handle,
+    poller: LinuxPoller,
+    allocator: std.mem.Allocator,
+    watches: std.AutoHashMap(Handle, []const u8),
+    arena: std.heap.ArenaAllocator,
+    evbuf: [16384]u8 align(8) = undefined,
+    evbuf_size: usize = 0,
+    event_queue: std.ArrayList(Event),
+
+    pub fn init(allocator: std.mem.Allocator) !Self {
         const fd = linux.inotify_init1(IN.NONBLOCK | IN.CLOEXEC);
         if (fd < 0) {
             return errnoToFsEventError(std.posix.errno(fd));
         }
+
+        errdefer _ = linux.close(fd);
+
         const poller = try LinuxPoller.init();
-        try poller.add(@intCast(fd));
+        errdefer poller.deinit();
+
+        _ = try poller.add(fd);
+
         return Self{
             .wfd = @intCast(fd),
             .poller = poller,
+            .allocator = allocator,
+            .watches = std.AutoHashMap(Handle, []const u8).init(allocator),
+            .arena = std.heap.ArenaAllocator.init(allocator),
+            .event_queue = .{},
         };
     }
 
-    pub fn add_watch(self: *const Self, target: WatchPath, filter: EventFilter) !WatchHandle {
+    pub fn add_watch(self: *Self, target: []const u8, filter: EventFilter) !WatchHandle {
+        if (target.len + 1 > std.fs.max_path_bytes) {
+            return error.NameTooLong;
+        }
+        var cstr_target_buf: [std.fs.max_path_bytes]u8 = undefined;
+        @memcpy(cstr_target_buf[0..target.len], target);
+        cstr_target_buf[target.len] = 0;
+        const cstr_target: [*:0]const u8 = @ptrCast(&cstr_target_buf[0]);
+
         const mask = eventFilterToBits(filter);
         if (mask == 0) return FsEventError.InvalidArguments;
-        const wd = linux.inotify_add_watch(@intCast(self.wfd), target.cstr(), mask);
+        const wd = linux.inotify_add_watch(@intCast(self.wfd), cstr_target, mask);
         if (wd < 0) {
             return errnoToFsEventError(std.posix.errno(wd));
         }
+        try self.watches.put(@intCast(wd), try self.allocator.dupe(u8, target));
         return @intCast(wd);
     }
 
-    pub fn poll(self: *const Self) !usize {
+    pub fn rm_watch(self: *Self, handle: Handle) !void {
+        const res = linux.inotify_rm_watch(@intCast(self.wfd), @intCast(handle));
+        if (res < 0) {
+            return errnoToFsEventError(std.posix.errno(res));
+        }
+        if (self.watches.fetchRemove(handle)) |entry| {
+            self.allocator.free(entry.value);
+        }
+    }
+
+    pub fn poll(self: *Self, timeout_ms: ?i32) !bool {
+        _ = self.arena.reset(.retain_capacity);
+        self.event_queue.clearRetainingCapacity();
+        const allocator = self.arena.allocator();
+
         var buf: [20]linux.epoll_event = undefined;
-        const count = try self.poller.wait(&buf, 0);
-        std.log.debug("{}", .{count});
+        const count = try self.poller.wait(&buf, timeout_ms orelse -1);
+
         for (buf[0..count]) |event| {
             if (event.data.fd == self.wfd) {
-                var offset: usize = 0;
-                var evbuf: [4096]u8 = undefined;
-                const bytes_read = linux.read(@intCast(self.wfd), &evbuf, evbuf.len);
-                if (bytes_read < 0) return errnoToFsEventError(std.posix.errno(bytes_read));
-                const size: usize = @intCast(bytes_read);
-                while (offset < size) {
-                    const e: *align(1) linux.inotify_event = @ptrCast(&evbuf[offset]);
-                    const event_length = @sizeOf(linux.inotify_event) + e.len;
-                    if (offset + event_length > size) break;
-                    const result: Event = .{
-                        .handle = e.wd,
-                        .type = try inotifyEventToEvent(e.mask),
-                        .path = "",
-                        .timestamp = 0,
-                        .extra = null,
-                    };
-                    std.log.debug("{any}", .{result});
-                    offset += event_length;
+                while (true) {
+                    const result = linux.read(@intCast(self.wfd), &self.evbuf, self.evbuf.len);
+                    const size: isize = @as(isize, @bitCast(result));
+                    if (size < 0) {
+                        const err = std.posix.errno(size);
+                        if (err == .AGAIN) break;
+                        return errnoToFsEventError(err);
+                    }
+
+                    if (size == 0) break;
+
+                    var offset: usize = 0;
+                    while (offset < size) {
+                        const e: *linux.inotify_event = @ptrCast(@alignCast(&self.evbuf[offset]));
+                        const e_length = @sizeOf(linux.inotify_event) + e.len;
+
+                        const base_path = self.watches.get(e.wd) orelse {
+                            offset += e_length;
+                            continue;
+                        };
+
+                        const full_path = if (e.len > 0) blk: {
+                            const name_ptr = e.getName().?;
+                            break :blk try std.fs.path.join(allocator, &.{ base_path, name_ptr });
+                        } else base_path;
+
+                        try self.event_queue.append(allocator, .{
+                            .handle = e.wd,
+                            .type = try inotifyEventToEvent(e.mask),
+                            .path = full_path,
+                            .timestamp = 0,
+                            .extra = null,
+                        });
+
+                        offset += e_length;
+                    }
                 }
             }
         }
-        return count;
+        return self.event_queue.items.len > 0;
+    }
+
+    pub fn nextEvent(self: *Self, it: *EventIterator) !?Event {
+        if (it.offset < self.event_queue.items.len) {
+            defer it.offset += 1;
+            return self.event_queue.items[it.offset];
+        }
+        return null;
     }
 
     pub fn deinit(self: *Self) void {
+        var iter = self.watches.valueIterator();
+        while (iter.next()) |v| {
+            self.allocator.free(v.*);
+        }
+        self.event_queue.deinit(self.arena.allocator());
+        self.watches.deinit();
+        self.arena.deinit();
         self.poller.deinit();
         _ = linux.close(@intCast(self.wfd));
     }
@@ -120,30 +194,30 @@ pub const LinuxWatcher = struct {
 
 pub const LinuxPoller = struct {
     const Self = @This();
-    epfd: usize,
+    epfd: i32,
 
     pub fn init() !Self {
         const fd = linux.epoll_create1(linux.EPOLL.CLOEXEC);
         if (fd < 0) return errnoToFsEventError(std.posix.errno(fd));
-        return Self{ .epfd = fd };
+        return Self{ .epfd = @intCast(fd) };
     }
 
-    pub fn add(self: *const Self, fd: WatchHandle) !void {
+    pub fn add(self: *const Self, fd: usize) !void {
         var event = linux.epoll_event{
             .events = linux.EPOLL.IN,
             .data = .{ .fd = @intCast(fd) },
         };
-        const rc = linux.epoll_ctl(@intCast(self.epfd), linux.EPOLL.CTL_ADD, @intCast(fd), &event);
-        if (rc < 0) return errnoToFsEventError(std.posix.errno(rc));
+        const result = linux.epoll_ctl(self.epfd, linux.EPOLL.CTL_ADD, @intCast(fd), &event);
+        if (result < 0) return errnoToFsEventError(std.posix.errno(result));
     }
 
     pub fn wait(self: *const Self, events: []linux.epoll_event, timeout_ms: i32) !usize {
-        const rc = linux.epoll_wait(@intCast(self.epfd), events.ptr, @intCast(events.len), timeout_ms);
-        if (rc < 0) return errnoToFsEventError(std.posix.errno(rc));
-        return rc;
+        const result = linux.epoll_wait(self.epfd, events.ptr, @intCast(events.len), timeout_ms);
+        if (result < 0) return errnoToFsEventError(std.posix.errno(result));
+        return result;
     }
 
     pub fn deinit(self: *Self) void {
-        _ = linux.close(@intCast(self.epfd));
+        _ = linux.close(self.epfd);
     }
 };

--- a/src/backends/linux.zig
+++ b/src/backends/linux.zig
@@ -30,9 +30,8 @@ fn eventFilterToBits(filter: EventFilter) u32 {
 }
 
 fn inotifyEventToEvent(mask: u32) !EventType {
-    const event_mask = mask & (IN.CREATE | IN.MODIFY | IN.DELETE);
     inline for (mapInotifyEvent) |entry| {
-        if (event_mask == entry.mask) return entry.event;
+        if (mask & entry.mask != 0) return entry.event;
     }
     return FsEventError.Unexpected;
 }

--- a/src/backends/linux.zig
+++ b/src/backends/linux.zig
@@ -105,7 +105,9 @@ pub const LinuxWatcher = struct {
         if (wd < 0) {
             return errnoToFsEventError(std.posix.errno(wd));
         }
-        try self.watches.put(@intCast(wd), try self.allocator.dupe(u8, target));
+        const duped_target = try self.allocator.dupe(u8, target);
+        errdefer self.allocator.free(duped_target);
+        try self.watches.put(@intCast(wd), duped_target);
         return @intCast(wd);
     }
 

--- a/src/backends/linux.zig
+++ b/src/backends/linux.zig
@@ -156,7 +156,7 @@ pub const LinuxWatcher = struct {
                             break :blk try std.fs.path.join(allocator, &.{ base_path, name_ptr });
                         } else base_path;
 
-                        try self.event_queue.append(allocator, .{
+                        try self.event_queue.append(self.allocator, .{
                             .handle = e.wd,
                             .type = try inotifyEventToEvent(e.mask),
                             .path = full_path,
@@ -185,7 +185,7 @@ pub const LinuxWatcher = struct {
         while (iter.next()) |v| {
             self.allocator.free(v.*);
         }
-        self.event_queue.deinit(self.arena.allocator());
+        self.event_queue.deinit(self.allocator);
         self.watches.deinit();
         self.arena.deinit();
         self.poller.deinit();

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 
 pub const Watcher = @import("Watcher.zig").Watcher;
-pub const WatchPath = @import("Watcher.zig").WatchPath;
 pub const Event = @import("Event.zig").Event;
+pub const EventIterator = @import("Event.zig").EventIterator;
 pub const EventFilter = @import("Event.zig").EventFilter;
 
 pub const EventMaskCreate = @import("Event.zig").EventMaskCreate;

--- a/src/root.zig
+++ b/src/root.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub const Watcher = @import("Watcher.zig").Watcher;
 pub const Event = @import("Event.zig").Event;
-pub const EventIterator = @import("Event.zig").EventIterator;
+pub const EventIterator = @import("Watcher.zig").EventIterator;
 pub const EventFilter = @import("Event.zig").EventFilter;
 
 pub const EventMaskCreate = @import("Event.zig").EventMaskCreate;


### PR DESCRIPTION
Change ID: qmpmrzrm
This commit contains the following changes:
    M .gitignore
    M examples/simple.zig
    M scripts/dev-session.sh
    M src/Event.zig
    M src/Watcher.zig
    M src/backends/linux.zig
    M src/root.zig

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Polling can return an event iterator and supports optional timeouts for non-blocking event consumption.

* **Refactor**
  * Watcher lifecycle now uses allocator-backed init/deinit and an OS-backed watcher abstraction; path handling simplified to direct strings and event iteration surfaced.

* **Chores**
  * Added session-* to ignore rules; development session now launches a different editor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->